### PR TITLE
Fix windows panic on os.Rename when target file exists

### DIFF
--- a/atomicfile.go
+++ b/atomicfile.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // File behaves like os.File, but does an atomic rename operation at Close.
@@ -33,6 +34,11 @@ func New(path string, mode os.FileMode) (*File, error) {
 func (f *File) Close() error {
 	if err := f.File.Close(); err != nil {
 		return err
+	}
+	if runtime.GOOS == "windows" {
+		if err := os.Remove(f.path); err != nil {
+			return err
+		}
 	}
 	if err := os.Rename(f.Name(), f.path); err != nil {
 		return err


### PR DESCRIPTION
Try to delete it first, but only on windows since it isn't atomic at all.
