### PR TITLE
Remove redundant if ...; err != nil checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: go
 
 go:
-  - 1.4
+  - 1.9
 
 before_install:
-  - go get -v golang.org/x/tools/cmd/vet
   - go get -v golang.org/x/tools/cmd/cover
   - go get -v github.com/golang/lint/golint
 

--- a/atomicfile.go
+++ b/atomicfile.go
@@ -38,10 +38,7 @@ func (f *File) Close() error {
 		os.Remove(f.File.Name())
 		return err
 	}
-	if err := os.Rename(f.Name(), f.path); err != nil {
-		return err
-	}
-	return nil
+	return os.Rename(f.Name(), f.path)
 }
 
 // Abort closes the file and removes it instead of replacing the configured
@@ -52,8 +49,5 @@ func (f *File) Abort() error {
 		os.Remove(f.Name())
 		return err
 	}
-	if err := os.Remove(f.Name()); err != nil {
-		return err
-	}
-	return nil
+	return os.Remove(f.Name())
 }


### PR DESCRIPTION
Fixes golint warnings:
```
$ golint ./...
atomicfile.go:41:2: redundant if ...; err != nil check, just return error instead.
atomicfile.go:55:2: redundant if ...; err != nil check, just return error instead.
```
